### PR TITLE
fix: resolve QA blockers — dashboard bug + accessibility

### DIFF
--- a/frontend/src/components/RSVPForm.tsx
+++ b/frontend/src/components/RSVPForm.tsx
@@ -69,6 +69,7 @@ export function RSVPForm({ slug, onSuccess }: RSVPFormProps) {
               key={btn.value}
               type="button"
               onClick={() => setStatus(btn.value)}
+              aria-pressed={status === btn.value}
               className={`flex-1 py-2 rounded-lg border text-sm font-medium transition-colors ${status === btn.value ? btn.active + ' border-transparent' : 'border-slate-300 text-slate-600 hover:bg-slate-50'}`}
             >
               {btn.label}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -9,7 +9,10 @@ import { api } from '../lib/api'
 export default function DashboardPage() {
   const { data, isLoading, error } = useQuery({
     queryKey: ['my-events'],
-    queryFn: () => api.get<Event[]>('/api/events'),
+    queryFn: async () => {
+      const res = await api.get<{ data: Event[]; pagination: unknown }>('/api/events');
+      return res.data;
+    },
   })
 
   const [events, setEvents] = useState<Event[] | null>(null)


### PR DESCRIPTION
Fixes the two QA issues blocking production:

1. **ISSUE-01 (Blocker):** DashboardPage expected `Event[]` from `/api/events` but the API returns `{ data, pagination }`. Now unwraps correctly.
2. **ISSUE-05 (A11y):** RSVP status toggle buttons now have `aria-pressed` for screen reader support.

Ref: docs/QA_REPORT.md